### PR TITLE
Rebrand codex CLI to asne

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-<h1 align="center">OpenAI Codex CLI</h1>
+<h1 align="center">Asne CLI</h1>
 <p align="center">Lightweight coding agent that runs in your terminal</p>
 
-<p align="center"><code>npm i -g @openai/codex</code></p>
+<p align="center"><code>npm i -g @asne/cli</code></p>
 
 > [!IMPORTANT]
-> This is the documentation for the _legacy_ TypeScript implementation of the Codex CLI. It has been superseded by the _Rust_ implementation. See the [README in the root of the Codex repository](https://github.com/openai/codex/blob/main/README.md) for details.
+> This is the documentation for the _legacy_ TypeScript implementation of the Asne CLI. It has been superseded by the _Rust_ implementation. See the [README in the root of the Asne repository](https://github.com/xuda1979/auto_scientist_n_engineer/blob/main/README.md) for details.
 
 > [!NOTE]
 > This fork automatically selects the default option (and chooses all when available) after 10 seconds of inactivity when the CLI prompts for input.
 
-![Codex demo GIF using: codex "explain this codebase to me"](../.github/demo.gif)
+![Asne demo GIF using: asne "explain this codebase to me"](../.github/demo.gif)
 
 ---
 
@@ -21,7 +21,7 @@
 - [Experimental technology disclaimer](#experimental-technology-disclaimer)
 - [Quickstart](#quickstart)
 - [Run locally](#run-locally)
-- [Why Codex?](#why-codex)
+- [Why Asne?](#why-asne)
 - [Security model & permissions](#security-model--permissions)
   - [Platform sandboxing details](#platform-sandboxing-details)
 - [System requirements](#system-requirements)
@@ -41,7 +41,7 @@
   - [Environment variables setup](#environment-variables-setup)
 - [FAQ](#faq)
 - [Zero data retention (ZDR) usage](#zero-data-retention-zdr-usage)
-- [Codex open source fund](#codex-open-source-fund)
+- [Asne open source fund](#asne-open-source-fund)
 - [Contributing](#contributing)
   - [Development workflow](#development-workflow)
   - [Git hooks with Husky](#git-hooks-with-husky)
@@ -53,7 +53,7 @@
   - [Getting help](#getting-help)
   - [Contributor license agreement (CLA)](#contributor-license-agreement-cla)
     - [Quick fixes](#quick-fixes)
-  - [Releasing `codex`](#releasing-codex)
+  - [Releasing `asne`](#releasing-asne)
   - [Alternative build options](#alternative-build-options)
     - [Nix flake development](#nix-flake-development)
 - [Security & responsible AI](#security--responsible-ai)
@@ -67,7 +67,7 @@
 
 ## Experimental technology disclaimer
 
-Codex CLI is an experimental project under active development. It is not yet stable, may contain bugs, incomplete features, or undergo breaking changes. We're building it in the open with the community and welcome:
+Asne CLI is an experimental project under active development. It is not yet stable, may contain bugs, incomplete features, or undergo breaking changes. We're building it in the open with the community and welcome:
 
 - Bug reports
 - Feature requests
@@ -81,7 +81,7 @@ Help us improve by filing issues or submitting PRs (see the section below for ho
 Install globally:
 
 ```shell
-npm install -g @openai/codex
+npm install -g @asne/cli
 ```
 
 Next, set your OpenAI API key as an environment variable:
@@ -101,7 +101,7 @@ export OPENAI_API_KEY="your-api-key-here"
 <details>
 <summary><strong>Use <code>--provider</code> to use other models</strong></summary>
 
-> Codex also allows you to use other providers that support the OpenAI Chat Completions API. You can set the provider in the config file or use the `--provider` flag. The possible options for `--provider` are:
+> Asne also allows you to use other providers that support the OpenAI Chat Completions API. You can set the provider in the config file or use the `--provider` flag. The possible options for `--provider` are:
 >
 > - openai (default)
 > - openrouter
@@ -133,20 +133,20 @@ export OPENAI_API_KEY="your-api-key-here"
 Run interactively:
 
 ```shell
-codex
+asne
 ```
 
 Or, run with a prompt as input (and optionally in `Full Auto` mode):
 
 ```shell
-codex "explain this codebase to me"
+asne "explain this codebase to me"
 ```
 
 ```shell
-codex --approval-mode full-auto "create the fanciest todo-list app"
+asne --approval-mode full-auto "create the fanciest todo-list app"
 ```
 
-That's it - Codex will scaffold a file, run it inside a sandbox, install any
+That's it - Asne will scaffold a file, run it inside a sandbox, install any
 missing dependencies, and show you the live result. Approve the changes and
 they'll be committed to your working directory.
 
@@ -171,7 +171,7 @@ they'll be committed to your working directory.
 3. **Start the CLI from the checked-out source:**
 
     ```bash
-    npx codex
+    npx asne
     ```
 
 4. **Run tests (optional):**
@@ -182,9 +182,9 @@ they'll be committed to your working directory.
 
 The CLI waits 10 seconds for input at any prompt. If you do nothing, it automatically chooses the default option or selects all options when supported.
 
-## Why Codex?
+## Why Asne?
 
-Codex CLI is built for developers who already **live in the terminal** and want
+Asne CLI is built for for developers who already **live in the terminal** and want
 ChatGPT-level reasoning **plus** the power to actually run code, manipulate
 files, and iterate - all under version control. In short, it's _chat-driven
 development_ that understands and executes your repo.
@@ -199,7 +199,7 @@ And it's **fully open-source** so you can see and contribute to how it develops!
 
 ## Security model & permissions
 
-Codex lets you decide _how much autonomy_ the agent receives and auto-approval policy via the
+Asne lets you decide _how much autonomy_ the agent receives and auto-approval policy via the
 `--approval-mode` flag (or the interactive onboarding prompt):
 
 | Mode                      | What the agent may do without asking                                                                | Still requires approval                                                                         |
@@ -209,7 +209,7 @@ Codex lets you decide _how much autonomy_ the agent receives and auto-approval p
 | **Full Auto**             | <li>Read/write files <li> Execute shell commands (network disabled, writes limited to your workdir) | -                                                                                               |
 
 In **Full Auto** every command is run **network-disabled** and confined to the
-current working directory (plus temporary files) for defense-in-depth. Codex
+current working directory (plus temporary files) for defense-in-depth. Asne
 will also show a warning/confirmation if you start in **auto-edit** or
 **full-auto** while the directory is _not_ tracked by Git, so you always have a
 safety net.
@@ -219,21 +219,21 @@ the network enabled, once we're confident in additional safeguards.
 
 ### Platform sandboxing details
 
-The hardening mechanism Codex uses depends on your OS:
+The hardening mechanism Asne uses depends on your OS:
 
 - **macOS 12+** - commands are wrapped with **Apple Seatbelt** (`sandbox-exec`).
 
   - Everything is placed in a read-only jail except for a small set of
-    writable roots (`$PWD`, `$TMPDIR`, `~/.codex`, etc.).
+    writable roots (`$PWD`, `$TMPDIR`, `~/.asne`, etc.).
   - Outbound network is _fully blocked_ by default - even if a child process
     tries to `curl` somewhere it will fail.
 
 - **Linux** - there is no sandboxing by default.
-  We recommend using Docker for sandboxing, where Codex launches itself inside a **minimal
+  We recommend using Docker for sandboxing, where Asne launches itself inside a **minimal
   container image** and mounts your repo _read/write_ at the same path. A
   custom `iptables`/`ipset` firewall script denies all egress except the
   OpenAI API. This gives you deterministic, reproducible runs without needing
-  root on the host. You can use the [`run_in_container.sh`](../codex-cli/scripts/run_in_container.sh) script to set up the sandbox.
+  root on the host. You can use the [`run_in_container.sh`](./scripts/run_in_container.sh) script to set up the sandbox.
 
 ---
 
@@ -254,10 +254,10 @@ The hardening mechanism Codex uses depends on your OS:
 
 | Command                              | Purpose                             | Example                              |
 | ------------------------------------ | ----------------------------------- | ------------------------------------ |
-| `codex`                              | Interactive REPL                    | `codex`                              |
-| `codex "..."`                        | Initial prompt for interactive REPL | `codex "fix lint errors"`            |
-| `codex -q "..."`                     | Non-interactive "quiet mode"        | `codex -q --json "explain utils.ts"` |
-| `codex completion <bash\|zsh\|fish>` | Print shell completion script       | `codex completion bash`              |
+| `asne`                              | Interactive REPL                    | `asne`                              |
+| `asne "..."`                        | Initial prompt for interactive REPL | `asne "fix lint errors"`            |
+| `asne -q "..."`                     | Non-interactive "quiet mode"        | `asne -q --json "explain utils.ts"` |
+| `asne completion <bash\|zsh\|fish>` | Print shell completion script       | `asne completion bash`              |
 
 Key flags: `--model/-m`, `--approval-mode/-a`, `--quiet/-q`, and `--notify`.
 
@@ -265,53 +265,53 @@ Key flags: `--model/-m`, `--approval-mode/-a`, `--quiet/-q`, and `--notify`.
 
 ## Memory & project docs
 
-You can give Codex extra instructions and guidance using `AGENTS.md` files. Codex looks for `AGENTS.md` files in the following places, and merges them top-down:
+You can give Asne extra instructions and guidance using `AGENTS.md` files. Asne looks for `AGENTS.md` files in the following places, and merges them top-down:
 
-1. `~/.codex/AGENTS.md` - personal global guidance
+1. `~/.asne/AGENTS.md` - personal global guidance
 2. `AGENTS.md` at repo root - shared project notes
 3. `AGENTS.md` in the current working directory - sub-folder/feature specifics
 
-Disable loading of these files with `--no-project-doc` or the environment variable `CODEX_DISABLE_PROJECT_DOC=1`.
+Disable loading of these files with `--no-project-doc` or the environment variable `ASNE_DISABLE_PROJECT_DOC=1`.
 
 ---
 
 ## Non-interactive / CI mode
 
-Run Codex head-less in pipelines. Example GitHub Action step:
+Run Asne head-less in pipelines. Example GitHub Action step:
 
 ```yaml
-- name: Update changelog via Codex
+- name: Update changelog via Asne
   run: |
-    npm install -g @openai/codex
+    npm install -g @asne/cli
     export OPENAI_API_KEY="${{ secrets.OPENAI_KEY }}"
-    codex -a auto-edit --quiet "update CHANGELOG for next release"
+    asne -a auto-edit --quiet "update CHANGELOG for next release"
 ```
 
-Set `CODEX_QUIET_MODE=1` to silence interactive UI noise.
+Set `ASNE_QUIET_MODE=1` to silence interactive UI noise.
 
 ## Tracing / verbose logging
 
 Setting the environment variable `DEBUG=true` prints full API request and response details:
 
 ```shell
-DEBUG=true codex
+DEBUG=true asne
 ```
 
 ---
 
 ## Recipes
 
-Below are a few bite-size examples you can copy-paste. Replace the text in quotes with your own task. See the [prompting guide](https://github.com/openai/codex/blob/main/codex-cli/examples/prompting_guide.md) for more tips and usage patterns.
+Below are a few bite-size examples you can copy-paste. Replace the text in quotes with your own task.
 
 | ✨  | What you type                                                                   | What happens                                                               |
 | --- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| 1   | `codex "Refactor the Dashboard component to React Hooks"`                       | Codex rewrites the class component, runs `npm test`, and shows the diff.   |
-| 2   | `codex "Generate SQL migrations for adding a users table"`                      | Infers your ORM, creates migration files, and runs them in a sandboxed DB. |
-| 3   | `codex "Write unit tests for utils/date.ts"`                                    | Generates tests, executes them, and iterates until they pass.              |
-| 4   | `codex "Bulk-rename *.jpeg -> *.jpg with git mv"`                               | Safely renames files and updates imports/usages.                           |
-| 5   | `codex "Explain what this regex does: ^(?=.*[A-Z]).{8,}$"`                      | Outputs a step-by-step human explanation.                                  |
-| 6   | `codex "Carefully review this repo, and propose 3 high impact well-scoped PRs"` | Suggests impactful PRs in the current codebase.                            |
-| 7   | `codex "Look for vulnerabilities and create a security review report"`          | Finds and explains security bugs.                                          |
+| 1   | `asne "Refactor the Dashboard component to React Hooks"`                       | Asne rewrites the class component, runs `npm test`, and shows the diff.   |
+| 2   | `asne "Generate SQL migrations for adding a users table"`                      | Infers your ORM, creates migration files, and runs them in a sandboxed DB. |
+| 3   | `asne "Write unit tests for utils/date.ts"`                                    | Generates tests, executes them, and iterates until they pass.              |
+| 4   | `asne "Bulk-rename *.jpeg -> *.jpg with git mv"`                               | Safely renames files and updates imports/usages.                           |
+| 5   | `asne "Explain what this regex does: ^(?=.*[A-Z]).{8,}$"`                      | Outputs a step-by-step human explanation.                                  |
+| 6   | `asne "Carefully review this repo, and propose 3 high impact well-scoped PRs"` | Suggests impactful PRs in the current codebase.                            |
+| 7   | `asne "Look for vulnerabilities and create a security review report"`          | Finds and explains security bugs.                                          |
 
 ---
 
@@ -321,13 +321,13 @@ Below are a few bite-size examples you can copy-paste. Replace the text in quote
 <summary><strong>From npm (Recommended)</strong></summary>
 
 ```bash
-npm install -g @openai/codex
+npm install -g @asne/cli
 # or
-yarn global add @openai/codex
+yarn global add @asne/cli
 # or
-bun install -g @openai/codex
+bun install -g @asne/cli
 # or
-pnpm add -g @openai/codex
+pnpm add -g @asne/cli
 ```
 
 </details>
@@ -337,8 +337,8 @@ pnpm add -g @openai/codex
 
 ```bash
 # Clone the repository and navigate to the CLI package
-git clone https://github.com/openai/codex.git
-cd codex/codex-cli
+git clone https://github.com/xuda1979/auto_scientist_n_engineer.git
+cd auto_scientist_n_engineer
 
 # Enable corepack
 corepack enable
@@ -366,7 +366,7 @@ pnpm link
 
 ## Configuration guide
 
-Codex configuration files can be placed in the `~/.codex/` directory, supporting both YAML and JSON formats.
+Asne configuration files can be placed in the `~/.asne/` directory, supporting both YAML and JSON formats.
 
 ### Basic configuration parameters
 
@@ -399,7 +399,7 @@ In the `history` object, you can configure conversation history settings:
 
 ### Configuration examples
 
-1. YAML format (save as `~/.codex/config.yaml`):
+1. YAML format (save as `~/.asne/config.yaml`):
 
 ```yaml
 model: o4-mini
@@ -408,7 +408,7 @@ fullAutoErrorMode: ask-user
 notify: true
 ```
 
-2. JSON format (save as `~/.codex/config.json`):
+2. JSON format (save as `~/.asne/config.json`):
 
 ```json
 {
@@ -489,7 +489,7 @@ Below is a comprehensive example of `config.json` with multiple custom providers
 
 ### Custom instructions
 
-You can create a `~/.codex/AGENTS.md` file to define custom guidance for the agent:
+You can create a `~/.asne/AGENTS.md` file to define custom guidance for the agent:
 
 ```markdown
 - Always respond with emojis
@@ -519,9 +519,9 @@ export OPENROUTER_API_KEY="your-openrouter-key-here"
 ## FAQ
 
 <details>
-<summary>OpenAI released a model called Codex in 2021 - is this related?</summary>
+<summary>OpenAI released a model called Asne in 2021 - is this related?</summary>
 
-In 2021, OpenAI released Codex, an AI system designed to generate code from natural language prompts. That original Codex model was deprecated as of March 2023 and is separate from the CLI tool.
+In 2021, OpenAI released Asne, an AI system designed to generate code from natural language prompts. That original Asne model was deprecated as of March 2023 and is separate from the CLI tool.
 
 </details>
 
@@ -539,15 +539,15 @@ It's possible that your [API account needs to be verified](https://help.openai.c
 </details>
 
 <details>
-<summary>How do I stop Codex from editing my files?</summary>
+<summary>How do I stop Asne from editing my files?</summary>
 
-Codex runs model-generated commands in a sandbox. If a proposed command or file change doesn't look right, you can simply type **n** to deny the command or give the model feedback.
+Asne runs model-generated commands in a sandbox. If a proposed command or file change doesn't look right, you can simply type **n** to deny the command or give the model feedback.
 
 </details>
 <details>
 <summary>Does it work on Windows?</summary>
 
-Not directly. It requires [Windows Subsystem for Linux (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/install) - Codex has been tested on macOS and Linux with Node 22.
+Not directly. It requires [Windows Subsystem for Linux (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/install) - Asne has been tested on macOS and Linux with Node 22.
 
 </details>
 
@@ -555,19 +555,19 @@ Not directly. It requires [Windows Subsystem for Linux (WSL2)](https://learn.mic
 
 ## Zero data retention (ZDR) usage
 
-Codex CLI **does** support OpenAI organizations with [Zero Data Retention (ZDR)](https://platform.openai.com/docs/guides/your-data#zero-data-retention) enabled. If your OpenAI organization has Zero Data Retention enabled and you still encounter errors such as:
+Asne CLI **does** support OpenAI organizations with [Zero Data Retention (ZDR)](https://platform.openai.com/docs/guides/your-data#zero-data-retention) enabled. If your OpenAI organization has Zero Data Retention enabled and you still encounter errors such as:
 
 ```
 OpenAI rejected the request. Error details: Status: 400, Code: unsupported_parameter, Type: invalid_request_error, Message: 400 Previous response cannot be used for this organization due to Zero Data Retention.
 ```
 
-You may need to upgrade to a more recent version with: `npm i -g @openai/codex@latest`
+You may need to upgrade to a more recent version with: `npm i -g @asne/cli@latest`
 
 ---
 
-## Codex open source fund
+## Asne open source fund
 
-We're excited to launch a **$1 million initiative** supporting open source projects that use Codex CLI and other OpenAI models.
+We're excited to launch a **$1 million initiative** supporting open source projects that use Asne CLI and other OpenAI models.
 
 - Grants are awarded up to **$25,000** API credits.
 - Applications are reviewed **on a rolling basis**.
@@ -625,7 +625,7 @@ pnpm format:fix
 
 ### Debugging
 
-To debug the CLI with a visual debugger, do the following in the `codex-cli` folder:
+To debug the CLI with a visual debugger, do the following in the `auto_scientist_n_engineer` folder:
 
 - Run `pnpm run build` to build the CLI, which will generate `cli.js.map` alongside `cli.js` in the `dist` folder.
 - Run the CLI with `node --inspect-brk ./dist/cli.js` The program then waits until a debugger is attached before proceeding. Options:
@@ -636,7 +636,7 @@ To debug the CLI with a visual debugger, do the following in the `codex-cli` fol
 
 1. **Start with an issue.** Open a new one or comment on an existing discussion so we can agree on the solution before code is written.
 2. **Add or update tests.** Every new feature or bug-fix should come with test coverage that fails before your change and passes afterwards. 100% coverage is not required, but aim for meaningful assertions.
-3. **Document behaviour.** If your change affects user-facing behaviour, update the README, inline help (`codex --help`), or relevant example projects.
+3. **Document behaviour.** If your change affects user-facing behaviour, update the README, inline help (`asne --help`), or relevant example projects.
 4. **Keep commits atomic.** Each commit should compile and the tests should pass. This makes reviews and potential rollbacks easier.
 
 ### Opening a pull request

--- a/bin/asne.js
+++ b/bin/asne.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Unified entry point for the Codex CLI.
+// Unified entry point for the Asne CLI.
 
 import path from "path";
 import { fileURLToPath } from "url";
@@ -57,7 +57,7 @@ if (!targetTriple) {
   throw new Error(`Unsupported platform: ${platform} (${arch})`);
 }
 
-const binaryPath = path.join(__dirname, "..", "bin", `codex-${targetTriple}`);
+const binaryPath = path.join(__dirname, "..", "bin", `asne-${targetTriple}`);
 
 // Use an asynchronous spawn instead of spawnSync so that Node is able to
 // respond to signals (e.g. Ctrl-C / SIGINT) while the native binary is
@@ -102,10 +102,10 @@ const updatedPath = getUpdatedPath(additionalDirs);
 
 const child = spawn(binaryPath, process.argv.slice(2), {
   stdio: "inherit",
-  env: { ...process.env, PATH: updatedPath, CODEX_MANAGED_BY_NPM: "1" },
+  env: { ...process.env, PATH: updatedPath, ASNE_MANAGED_BY_NPM: "1" },
 });
 
-// Automatically send input to the Codex CLI when it waits for user
+// Automatically send input to the Asne CLI when it waits for user
 // interaction. After 10 seconds of inactivity, send `a` followed by a newline
 // to select all options when supported; prompts that do not recognize `a`
 // will interpret the newline as choosing the default option.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,21 @@
 {
-  "name": "@openai/codex",
+  "name": "@asne/cli",
   "version": "0.0.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@openai/codex",
+      "name": "@asne/cli",
       "version": "0.0.0-dev",
       "license": "Apache-2.0",
       "dependencies": {
         "@vscode/ripgrep": "^1.15.14"
       },
       "bin": {
-        "codex": "bin/codex.js"
+        "asne": "bin/asne.js"
+      },
+      "devDependencies": {
+        "prettier": "^3.3.3"
       },
       "engines": {
         "node": ">=20"
@@ -98,6 +101,22 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "license": "MIT"
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@openai/codex",
+  "name": "@asne/cli",
   "version": "0.0.0-dev",
   "license": "Apache-2.0",
   "bin": {
-    "codex": "bin/codex.js"
+    "asne": "bin/asne.js"
   },
   "type": "module",
   "engines": {
@@ -15,10 +15,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openai/codex.git"
+    "url": "git+https://github.com/xuda1979/auto_scientist_n_engineer.git"
   },
   "scripts": {
-    "test": "node test/codex_cli.test.mjs"
+    "test": "node test/asne_cli.test.mjs"
   },
   "dependencies": {
     "@vscode/ripgrep": "^1.15.14"

--- a/test/asne_cli.test.mjs
+++ b/test/asne_cli.test.mjs
@@ -6,7 +6,7 @@ import path from 'path';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const cliPath = path.join(__dirname, '..', 'bin', 'codex.js');
+const cliPath = path.join(__dirname, '..', 'bin', 'asne.js');
 assert.ok(fs.existsSync(cliPath), 'CLI entry script should exist');
 
-console.log('codex CLI entry exists');
+console.log('asne CLI entry exists');


### PR DESCRIPTION
This commit rebrands the `codex` command-line tool to `asne`.

The following changes were made:
- Renamed `bin/codex.js` to `bin/asne.js` and `test/codex_cli.test.mjs` to `test/asne_cli.test.mjs`.
- Updated `package.json` to change the package name to `@asne/cli`, the binary command to `asne`, and the repository URL.
- Updated the `README.md` to replace "codex" with "asne" in all user-facing text.
- Updated the `bin/asne.js` file to change the binary path to `asne-` and the `CODEX_MANAGED_BY_NPM` environment variable to `ASNE_MANAGED_BY_NPM`.
- Added a `.gitignore` file to ignore `node_modules`.